### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Firebase Hosting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/MobiTheWale/NarroHome/security/code-scanning/4](https://github.com/MobiTheWale/NarroHome/security/code-scanning/4)

Add an explicit `permissions` block to the workflow YAML. The safest non-breaking default is to set `contents: read` at the workflow root, which applies to all jobs unless overridden. This satisfies CodeQL’s requirement and preserves current functionality for checkout/build/deploy unless a broader scope is actually needed later.

In `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
  contents: read
```

directly below `name:` (or before `jobs:`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
